### PR TITLE
issue 12: Central registry

### DIFF
--- a/lib/feature_flaggable.rb
+++ b/lib/feature_flaggable.rb
@@ -3,6 +3,9 @@
 require_relative 'feature_flaggable/version'
 require_relative 'feature_flaggable/config'
 require_relative 'feature_flaggable/railtie' if defined?(Rails::Railtie)
+require_relative 'feature_flaggable/registry'
+require_relative 'feature_flaggable/evaluator'
+require_relative 'feature_flaggable/dsl'
 
 # FeatureFlaggable provides a lightweight, Ruby-first feature flag DSL and YAML configuration
 # for Rails and Ruby applications. See README for usage and configuration details.
@@ -14,8 +17,41 @@ module FeatureFlaggable
       @config ||= Config.new
     end
 
+    def registry
+      @registry ||= Registry.new
+    end
+
+    def evaluator
+      @evaluator ||= Evaluator.new(registry: registry, config: config)
+    end
+
     def configure
       yield config if block_given?
+    end
+
+    def enabled?(flag, user:, context: {})
+      evaluator.enabled?(flag, user: user, context: context)
+    end
+
+    def overridden?(flag)
+      evaluator.overridden?(flag)
+    end
+
+    def override(flag, value)
+      registry.override(flag, value)
+    end
+
+    def clear_override(flag)
+      registry.clear_override(flag)
+    end
+
+    def define(&)
+      dsl = DSL.new(registry)
+      dsl.instance_eval(&) if block_given?
+    end
+
+    def flaggable(flag, user:, context: {})
+      yield if enabled?(flag, user: user, context: context)
     end
   end
 end

--- a/lib/feature_flaggable/dsl.rb
+++ b/lib/feature_flaggable/dsl.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module FeatureFlaggable
+  # DSL for registering segments and predicates for feature flags.
+  class DSL
+    def initialize(registry)
+      @registry = registry
+    end
+
+    def segment(name, &)
+      @registry.register_segment(name, &)
+    end
+
+    def predicate(name, &)
+      @registry.register_predicate(name, &)
+    end
+  end
+end

--- a/lib/feature_flaggable/evaluator.rb
+++ b/lib/feature_flaggable/evaluator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module FeatureFlaggable
+  # Evaluator determines if a feature flag is enabled for a given user and context.
+  class Evaluator
+    def initialize(registry:, config:, cache: nil)
+      @registry = registry
+      @config = config
+      @cache = cache
+    end
+  end
+end

--- a/lib/feature_flaggable/registry.rb
+++ b/lib/feature_flaggable/registry.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Registry stores feature flag overrides, segments, and predicates.
+module FeatureFlaggable
+  # Registry stores feature flag overrides, segments, and predicates.
+  class Registry
+    def initialize
+      @overrides = {}
+      @segments = {}
+      @predicates = {}
+    end
+
+    def override(flag, value)
+      @overrides[flag.to_sym] = value
+    end
+
+    def clear_override(flag)
+      @overrides.delete(flag.to_sym)
+    end
+
+    def overridden?(flag)
+      @overrides.key?(flag.to_sym)
+    end
+
+    def register_segment(name, &block)
+      @segments[name.to_sym] = block
+    end
+
+    def register_predicate(name, &block)
+      @predicates[name.to_sym] = block
+    end
+  end
+end

--- a/spec/feature_flaggable_spec.rb
+++ b/spec/feature_flaggable_spec.rb
@@ -31,3 +31,35 @@ RSpec.describe 'FeatureFlaggable Railtie integration' do
     expect { load File.expand_path('../lib/feature_flaggable.rb', __dir__) }.not_to raise_error
   end
 end
+
+RSpec.describe FeatureFlaggable, 'public API' do
+  let(:user) { double('User', user_type: :admin) }
+  let(:context) { { business: double('Business') } }
+
+  it 'can define segments and predicates' do
+    expect do
+      FeatureFlaggable.define do
+        segment :testers do |_user:, _context: {}|
+          true
+        end
+        predicate :always_true do |_user:, _context: {}|
+          true
+        end
+      end
+    end.not_to raise_error
+  end
+
+  it 'executes block in flaggable if enabled? returns true' do
+    allow(FeatureFlaggable).to receive(:enabled?).and_return(true)
+    result = nil
+    FeatureFlaggable.flaggable(:some_flag, user: user, context: context) { result = 42 }
+    expect(result).to eq(42)
+  end
+
+  it 'does not execute block in flaggable if enabled? returns false' do
+    allow(FeatureFlaggable).to receive(:enabled?).and_return(false)
+    result = nil
+    FeatureFlaggable.flaggable(:some_flag, user: user, context: context) { result = 42 }
+    expect(result).to be_nil
+  end
+end


### PR DESCRIPTION
Goal: Central registry storing config + runtime overrides + DSL callables.

## Tasks
* Register/resolve segment(name){|user:,context:|}, predicate(name){...}.
* Thread-safe overrides Hash + API stubs.

## Acceptance
* Specs for register/resolve; override CRUD.

closes #12 